### PR TITLE
Feature/card answers array input

### DIFF
--- a/lib/card.rb
+++ b/lib/card.rb
@@ -4,9 +4,9 @@
 class Card
   attr_reader :category, :question, :answers
 
-  def initialize(category, question, *answers)
+  def initialize(category, question, answers = [])
     @category = category
     @question = question
-    @answers = answers.flatten.map(&:downcase)
+    @answers = answers.map(&:downcase)
   end
 end

--- a/spec/card_spec.rb
+++ b/spec/card_spec.rb
@@ -4,10 +4,10 @@ require_relative '../lib/card'
 require 'rspec'
 
 describe Card do
-  let(:card) { described_class.new(:Geography, 'What is the capital of Alaska?', 'Juneau') }
+  let(:card) { described_class.new(:Geography, 'What is the capital of Alaska?', ['Juneau']) }
 
   describe '#initialize' do
-    subject(:card) { described_class.new(:Geography, 'What is the capital of Alaska?', 'Juneau') }
+    subject(:card) { described_class.new(:Geography, 'What is the capital of Alaska?', ['Juneau']) }
 
     it { is_expected.to be_instance_of(described_class) }
   end
@@ -52,7 +52,7 @@ describe Card do
     end
 
     context 'when multiple answers given' do
-      let(:card) { described_class.new(:Geography, 'What is the capital of Alaska?', 'Juneau', 'Alternate Answer') }
+      let(:card) { described_class.new(:Geography, 'What is the capital of Alaska?', ['Juneau', 'Alternate Answer']) }
 
       it 'returns array of answers' do
         expect(answers).to eq(['juneau', 'alternate answer'])

--- a/spec/deck_spec.rb
+++ b/spec/deck_spec.rb
@@ -5,10 +5,10 @@ require_relative '../lib/deck'
 require 'rspec'
 
 describe Deck do
-  let(:first_card) { Card.new(:Geography, 'What is the capital of Alaska?', 'Juneau') }
-  let(:second_card) { Card.new(:STEM, 'Who is the CEO of SpaceX?', 'Elon Musk') }
+  let(:first_card) { Card.new(:Geography, 'What is the capital of Alaska?', ['Juneau']) }
+  let(:second_card) { Card.new(:STEM, 'Who is the CEO of SpaceX?', ['Elon Musk']) }
   let(:third_card) do
-    Card.new(:STEM, 'Describe in words the exact direction of 697.5° clockwise from due north?', 'North north west')
+    Card.new(:STEM, 'Describe in words the exact direction of 697.5° clockwise from due north?', ['North north west'])
   end
   let(:cards) { [first_card, second_card, third_card] }
   let(:deck) { described_class.new(cards) }
@@ -52,9 +52,9 @@ describe Deck do
 
     context 'when category is not present' do
       it 'returns empty array' do
-        cards = [Card.new(:Geography, 'What is the capital of Alaska?', 'Juneau'),
-                 Card.new(:Fantasy, 'Who is the CEO of SpaceX?', 'Elon Musk'),
-                 Card.new(:Fantasy, 'Some question?', 'North north west')]
+        cards = [Card.new(:Geography, 'What is the capital of Alaska?', ['Juneau']),
+                 Card.new(:Fantasy, 'Who is the CEO of SpaceX?', ['Elon Musk']),
+                 Card.new(:Fantasy, 'Some question?', ['North north west'])]
         deck = described_class.new(cards)
 
         expect(deck.cards_in_category(:STEM)).to eq([])
@@ -75,9 +75,9 @@ describe Deck do
 
     context 'when category is a string' do
       it 'returns array of category strings' do
-        cards = [Card.new('Geography', 'What is the capital of Alaska?', 'Juneau'),
-                 Card.new('STEM', 'Who is the CEO of SpaceX?', 'Elon Musk'),
-                 Card.new('STEM', 'Some question?', 'North north west')]
+        cards = [Card.new('Geography', 'What is the capital of Alaska?', ['Juneau']),
+                 Card.new('STEM', 'Who is the CEO of SpaceX?', ['Elon Musk']),
+                 Card.new('STEM', 'Some question?', ['North north west'])]
         deck = described_class.new(cards)
 
         expect(deck.categories).to eq(%w[Geography STEM])

--- a/spec/round_spec.rb
+++ b/spec/round_spec.rb
@@ -8,9 +8,9 @@ require 'rspec'
 describe Round do
   let(:cards) do
     [
-      Card.new(:Geography, 'What is the capital of Alaska?', 'Juneau'),
-      Card.new(:STEM, 'Who is the CEO of SpaceX?', 'Elon Musk'),
-      Card.new(:STEM, 'Describe in words the exact direction of 697.5° clockwise from due north?', 'North north west')
+      Card.new(:Geography, 'What is the capital of Alaska?', ['Juneau']),
+      Card.new(:STEM, 'Who is the CEO of SpaceX?', ['Elon Musk']),
+      Card.new(:STEM, 'Describe in words the exact direction of 697.5° clockwise from due north?', ['North north west'])
     ]
   end
   let(:deck) { Deck.new(cards) }

--- a/spec/turn_spec.rb
+++ b/spec/turn_spec.rb
@@ -5,7 +5,7 @@ require_relative '../lib/turn'
 require 'rspec'
 
 describe Turn do
-  let(:card) { Card.new(:Geography, 'What is the capital of Alaska?', 'Juneau', 'alt') }
+  let(:card) { Card.new(:Geography, 'What is the capital of Alaska?', %w[Juneau alt]) }
   let(:turn) { described_class.new('Juneau', card) }
 
   describe '#initialize' do


### PR DESCRIPTION
Instead of calling `.flatten` on `answers` to account for the CardGenerator edge case, this makes the `answers` parameter an array in all cases. Updates tests to follow new format for creating new cards and updates `Card` class to remove the `.flatten` call and accept `answers` as an empty array by default.