### PR TITLE
Refactor/card_generator optimization

### DIFF
--- a/lib/card_generator.rb
+++ b/lib/card_generator.rb
@@ -8,7 +8,7 @@ class CardGenerator
   def initialize(filename)
     @cards = []
     File.open(filename, 'r').each_line do |line|
-      next if line.empty? || line.start_with?('#') || line.split(',').size < 2
+      next if line.start_with?('#') || line.split(',').size < 2
 
       card_array = line.split(',')
       card_array.last.chomp!


### PR DESCRIPTION
Removes the `line.empty?` call in the `CardGenerator` class because this would necessarily also trigger `line.split(',').size < 2`